### PR TITLE
domain 레이어의 GitHubRepo 모델을 추가합니다.

### DIFF
--- a/domain/src/main/java/model/GitHubRepoModel.kt
+++ b/domain/src/main/java/model/GitHubRepoModel.kt
@@ -2,7 +2,7 @@ package model
 
 import com.kimdoori.data.source.entity.GitHubRepoResponse
 
-data class GitHubRepo(
+data class GitHubRepoModel(
     val id: Int,
     val name: String,
     val fullName: String,
@@ -10,7 +10,7 @@ data class GitHubRepo(
     val url: String
 ) {
     companion object {
-        fun mapFromEntity(gitHubRepoResponse: GitHubRepoResponse) = GitHubRepo(
+        fun mapFromEntity(gitHubRepoResponse: GitHubRepoResponse) = GitHubRepoModel(
             id = gitHubRepoResponse.id,
             name = gitHubRepoResponse.name,
             fullName = gitHubRepoResponse.fullName,


### PR DESCRIPTION
# tl;dr

#8 

# 주요 변경 내용

- domain 모듈에 GitHubRepo model을 추가했습니다.
- data 레이어의 entity를 변환하는 mapFromEntity 메서드를 추가했습니다.

# 코드 리뷰

데이터 패키지 이름을 data 레이어는 entity로, domain 레어이는 model로 주려고 하는데 괜찮을까요?
찾아보니 예시마다 다 다르게 정하시길래 제 나름대로 적합할 것 같은 패키지명으로 정했습니다.


## 참고 사항

PR에 관련된 내용은 아니지만 #4 #5 를 이번 주말에 진행할 것 같습니다. 